### PR TITLE
Fix gradle URL

### DIFF
--- a/e2e-test/gradle/wrapper/gradle-wrapper.properties
+++ b/e2e-test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip

--- a/eureka-server/gradle/wrapper/gradle-wrapper.properties
+++ b/eureka-server/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-bin.zip

--- a/spring-boot-restful-service/gradle/wrapper/gradle-wrapper.properties
+++ b/spring-boot-restful-service/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip

--- a/spring-boot-webapp/gradle/wrapper/gradle-wrapper.properties
+++ b/spring-boot-webapp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip

--- a/zipkin-server/gradle/wrapper/gradle-wrapper.properties
+++ b/zipkin-server/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-bin.zip


### PR DESCRIPTION
When I tried to execute ``build-docker.sh`` the error bellow was given:

```java
Downloading http://services.gradle.org/distributions/gradle-2.11-all.zip

Exception in thread "main" java.lang.RuntimeException: java.io.IOException: Server returned HTTP response code: 403 for URL: http://services.gradle.org/distributions/gradle-2.11-all.zip
	at org.gradle.wrapper.ExclusiveFileAccessManager.access(ExclusiveFileAccessManager.java:78)
	at org.gradle.wrapper.Install.createDist(Install.java:47)
	at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:129)
	at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)
Caused by: java.io.IOException: Server returned HTTP response code: 403 for URL: http://services.gradle.org/distributions/gradle-2.11-all.zip
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1876)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1474)
	at org.gradle.wrapper.Download.downloadInternal(Download.java:59)
	at org.gradle.wrapper.Download.download(Download.java:45)
	at org.gradle.wrapper.Install$1.call(Install.java:60)
	at org.gradle.wrapper.Install$1.call(Install.java:47)
	at org.gradle.wrapper.ExclusiveFileAccessManager.access(ExclusiveFileAccessManager.java:65)
	... 3 more

```

This pull request resolves this error by changing HTTP protocol to HTTPS.